### PR TITLE
enable pzstd build on Unices

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,6 +11,8 @@ fi
 
 # Build
 make -j$CPU_COUNT
+make -j$CPU_COUNT -C contrib/pzstd all
 
 # Install
 make install PREFIX=$PREFIX
+make -C contrib/pzstd install PREFIX=$PREFIX

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/0004-Rename-zstdlib-to-libzstd-internally-VS2008.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and py35]
   features:
     - vc9   # [win and py27]
@@ -36,6 +36,7 @@ test:
 
   commands:
     - zstd -be -i5
+    - pzstd --version 2> /dev/null  # [unix]
 
     - test -f ${PREFIX}/include/{{ name }}.h     # [unix]
     - test -f ${PREFIX}/lib/lib{{ name }}.a      # [unix]


### PR DESCRIPTION
`zstd` doesn't yet thread decompression. In the meantime, `pzstd` can be incredibly fast when decompressing using multiple cores. This PR enables building `pzstd` from the contrib directory on Linux/OSX. I don't know how to enable `pzstd` builds on Windows, or if it is even possible.